### PR TITLE
Add basic Auto Download toggling for podcasts

### DIFF
--- a/Podverse/AboutPlayingItemViewController.swift
+++ b/Podverse/AboutPlayingItemViewController.swift
@@ -12,6 +12,8 @@ class AboutPlayingItemViewController: UIViewController, UIWebViewDelegate {
 
     @IBOutlet weak var webView: UIWebView!
     
+    let pvMediaPlayer = PVMediaPlayer.shared
+    
     override func viewDidLoad() {
         super.viewDidLoad()
         

--- a/Podverse/Base.lproj/Main.storyboard
+++ b/Podverse/Base.lproj/Main.storyboard
@@ -945,24 +945,29 @@
                                         <nil key="textColor"/>
                                         <nil key="highlightedColor"/>
                                     </label>
-                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="OJO-cg-T72">
-                                        <rect key="frame" x="280" y="62" width="87" height="30"/>
-                                        <fontDescription key="fontDescription" type="system" pointSize="15"/>
-                                        <state key="normal" title="Auto DL OFF">
-                                            <color key="titleColor" red="0.0" green="0.47843137250000001" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
-                                        </state>
+                                    <switch opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" contentHorizontalAlignment="center" contentVerticalAlignment="center" on="YES" translatesAutoresizingMaskIntoConstraints="NO" id="yez-rs-zzS">
+                                        <rect key="frame" x="318" y="53" width="51" height="31"/>
+                                        <color key="onTintColor" red="0.0" green="0.47843137250000001" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                         <connections>
-                                            <action selector="autoDownloadButtonTouched:" destination="DYF-Bg-yz8" eventType="touchUpInside" id="OxT-eM-mS7"/>
+                                            <action selector="autoDownloadSwitchTouched:" destination="DYF-Bg-yz8" eventType="valueChanged" id="woQ-eS-PNl"/>
                                         </connections>
-                                    </button>
+                                    </switch>
+                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Auto DL" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="TnX-z2-VIN">
+                                        <rect key="frame" x="255" y="59" width="55" height="18"/>
+                                        <fontDescription key="fontDescription" type="system" pointSize="15"/>
+                                        <nil key="textColor"/>
+                                        <nil key="highlightedColor"/>
+                                    </label>
                                 </subviews>
                                 <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                                 <constraints>
                                     <constraint firstAttribute="height" constant="92" id="D3u-CA-JcY"/>
+                                    <constraint firstAttribute="trailing" secondItem="yez-rs-zzS" secondAttribute="trailing" constant="8" id="MT3-Qo-UWs"/>
                                     <constraint firstItem="W2q-RV-W1m" firstAttribute="leading" secondItem="yDP-ef-HEq" secondAttribute="leading" constant="8" id="MZD-Pt-ALq"/>
-                                    <constraint firstAttribute="bottom" secondItem="OJO-cg-T72" secondAttribute="bottom" id="Na1-io-X12"/>
-                                    <constraint firstAttribute="trailing" secondItem="OJO-cg-T72" secondAttribute="trailing" constant="8" id="rSS-B8-DZf"/>
+                                    <constraint firstItem="yez-rs-zzS" firstAttribute="leading" secondItem="TnX-z2-VIN" secondAttribute="trailing" constant="8" id="a3y-Os-bRk"/>
+                                    <constraint firstAttribute="bottom" secondItem="TnX-z2-VIN" secondAttribute="bottom" constant="15" id="i9b-xS-j59"/>
                                     <constraint firstItem="W2q-RV-W1m" firstAttribute="top" secondItem="yDP-ef-HEq" secondAttribute="top" constant="8" id="x5u-2l-iaK"/>
+                                    <constraint firstAttribute="bottom" secondItem="yez-rs-zzS" secondAttribute="bottom" constant="8" id="ybe-Qm-G8b"/>
                                 </constraints>
                             </view>
                         </subviews>
@@ -978,7 +983,8 @@
                         </constraints>
                     </view>
                     <connections>
-                        <outlet property="autoDownloadButton" destination="OJO-cg-T72" id="B0H-3r-Ssf"/>
+                        <outlet property="autoDownloadLabel" destination="TnX-z2-VIN" id="jUQ-rY-nCP"/>
+                        <outlet property="autoDownloadSwitch" destination="yez-rs-zzS" id="u4r-5a-L2r"/>
                         <outlet property="bottomButton" destination="VOa-dX-ejH" id="akg-G5-uRs"/>
                         <outlet property="headerImageView" destination="W2q-RV-W1m" id="y4A-4E-KUw"/>
                         <outlet property="headerPodcastTitle" destination="4bn-tB-LUD" id="iII-EY-sLo"/>

--- a/Podverse/Base.lproj/Main.storyboard
+++ b/Podverse/Base.lproj/Main.storyboard
@@ -214,8 +214,14 @@
                                                     <color key="textColor" white="0.33333333333333331" alpha="1" colorSpace="calibratedWhite"/>
                                                     <nil key="highlightedColor"/>
                                                 </label>
-                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Episodes downloaded" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="tvC-4n-69O">
-                                                    <rect key="frame" x="92" y="68" width="133" height="16"/>
+                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="# downloaded" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="tvC-4n-69O">
+                                                    <rect key="frame" x="92" y="68" width="86" height="16"/>
+                                                    <fontDescription key="fontDescription" type="system" pointSize="13"/>
+                                                    <color key="textColor" white="0.33333333333333331" alpha="1" colorSpace="calibratedWhite"/>
+                                                    <nil key="highlightedColor"/>
+                                                </label>
+                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="AutoDL" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="H5L-K1-HNR">
+                                                    <rect key="frame" x="322" y="48" width="45" height="16"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="13"/>
                                                     <color key="textColor" white="0.33333333333333331" alpha="1" colorSpace="calibratedWhite"/>
                                                     <nil key="highlightedColor"/>
@@ -223,17 +229,20 @@
                                             </subviews>
                                             <constraints>
                                                 <constraint firstItem="nHK-v5-PZN" firstAttribute="leading" secondItem="uk6-qB-t6M" secondAttribute="trailing" constant="8" id="1im-Zf-hBc"/>
+                                                <constraint firstItem="wxe-bv-W6i" firstAttribute="top" secondItem="H5L-K1-HNR" secondAttribute="bottom" constant="4" id="6j9-Sg-cZw"/>
                                                 <constraint firstItem="uk6-qB-t6M" firstAttribute="leading" secondItem="HcB-O2-XAh" secondAttribute="leadingMargin" id="BKt-Iz-OVa"/>
                                                 <constraint firstItem="nHK-v5-PZN" firstAttribute="top" secondItem="HcB-O2-XAh" secondAttribute="topMargin" id="K56-a6-kRx"/>
                                                 <constraint firstItem="uk6-qB-t6M" firstAttribute="top" secondItem="HcB-O2-XAh" secondAttribute="topMargin" id="Kct-Vg-tce"/>
                                                 <constraint firstAttribute="bottom" secondItem="wxe-bv-W6i" secondAttribute="bottom" constant="7.5" id="Lgx-Cz-VDK"/>
                                                 <constraint firstItem="nHK-v5-PZN" firstAttribute="trailing" secondItem="HcB-O2-XAh" secondAttribute="trailingMargin" id="M66-Ej-P5f"/>
+                                                <constraint firstItem="tvC-4n-69O" firstAttribute="leading" secondItem="uk6-qB-t6M" secondAttribute="trailing" constant="8" id="OMw-YE-Blr"/>
                                                 <constraint firstAttribute="trailing" secondItem="wxe-bv-W6i" secondAttribute="trailing" constant="8" id="OxA-Ic-2Go"/>
-                                                <constraint firstItem="tvC-4n-69O" firstAttribute="leading" secondItem="uk6-qB-t6M" secondAttribute="trailing" constant="8" id="ZeE-0y-R8W"/>
-                                                <constraint firstItem="tvC-4n-69O" firstAttribute="bottom" secondItem="HcB-O2-XAh" secondAttribute="bottomMargin" id="yeZ-vf-McR"/>
+                                                <constraint firstAttribute="trailingMargin" secondItem="H5L-K1-HNR" secondAttribute="trailing" id="oF3-3P-M4P"/>
+                                                <constraint firstItem="tvC-4n-69O" firstAttribute="bottom" secondItem="HcB-O2-XAh" secondAttribute="bottomMargin" id="oOk-62-zfb"/>
                                             </constraints>
                                         </tableViewCellContentView>
                                         <connections>
+                                            <outlet property="autoDownloadIndicator" destination="H5L-K1-HNR" id="Gco-ms-1fQ"/>
                                             <outlet property="lastPublishedDate" destination="wxe-bv-W6i" id="Zf3-02-uI8"/>
                                             <outlet property="pvImage" destination="uk6-qB-t6M" id="OFj-bF-fNQ"/>
                                             <outlet property="title" destination="nHK-v5-PZN" id="XaK-zi-Jwb"/>
@@ -936,11 +945,23 @@
                                         <nil key="textColor"/>
                                         <nil key="highlightedColor"/>
                                     </label>
+                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="OJO-cg-T72">
+                                        <rect key="frame" x="280" y="62" width="87" height="30"/>
+                                        <fontDescription key="fontDescription" type="system" pointSize="15"/>
+                                        <state key="normal" title="Auto DL OFF">
+                                            <color key="titleColor" red="0.0" green="0.47843137250000001" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                        </state>
+                                        <connections>
+                                            <action selector="autoDownloadButtonTouched:" destination="DYF-Bg-yz8" eventType="touchUpInside" id="OxT-eM-mS7"/>
+                                        </connections>
+                                    </button>
                                 </subviews>
                                 <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                                 <constraints>
                                     <constraint firstAttribute="height" constant="92" id="D3u-CA-JcY"/>
                                     <constraint firstItem="W2q-RV-W1m" firstAttribute="leading" secondItem="yDP-ef-HEq" secondAttribute="leading" constant="8" id="MZD-Pt-ALq"/>
+                                    <constraint firstAttribute="bottom" secondItem="OJO-cg-T72" secondAttribute="bottom" id="Na1-io-X12"/>
+                                    <constraint firstAttribute="trailing" secondItem="OJO-cg-T72" secondAttribute="trailing" constant="8" id="rSS-B8-DZf"/>
                                     <constraint firstItem="W2q-RV-W1m" firstAttribute="top" secondItem="yDP-ef-HEq" secondAttribute="top" constant="8" id="x5u-2l-iaK"/>
                                 </constraints>
                             </view>
@@ -957,6 +978,7 @@
                         </constraints>
                     </view>
                     <connections>
+                        <outlet property="autoDownloadButton" destination="OJO-cg-T72" id="B0H-3r-Ssf"/>
                         <outlet property="bottomButton" destination="VOa-dX-ejH" id="akg-G5-uRs"/>
                         <outlet property="headerImageView" destination="W2q-RV-W1m" id="y4A-4E-KUw"/>
                         <outlet property="headerPodcastTitle" destination="4bn-tB-LUD" id="iII-EY-sLo"/>

--- a/Podverse/Constants.swift
+++ b/Podverse/Constants.swift
@@ -67,6 +67,8 @@ let kMyEpisodesPlaylist = "My Episodes"
 
 let kUserId = "userId"
 
+let kAutoDownloadingFeedUrls = "autoDownloadingFeedUrls"
+
 let kInternetIsUnreachable = "internetIsUnreachable"
 
 let kWiFiIsUnreachable = "wiFiIsUnreachable"

--- a/Podverse/EpisodesTableViewController.swift
+++ b/Podverse/EpisodesTableViewController.swift
@@ -1,8 +1,13 @@
 import UIKit
 import CoreData
 
+protocol AutoDownloadProtocol: NSObjectProtocol {
+    func podcastAutodownloadChanged(feedUrl: String)
+}
+
 class EpisodesTableViewController: PVViewController, UITableViewDataSource, UITableViewDelegate {
     
+    weak var delegate: AutoDownloadProtocol?
     var episodesArray = [Episode]()
     let moc = CoreDataHelper.createMOCForThread(threadType: .privateThread)
     let reachability = PVReachability.shared
@@ -23,6 +28,7 @@ class EpisodesTableViewController: PVViewController, UITableViewDataSource, UITa
             } else {
                 podcast.addToAutoDownloadList()
             }
+            self.delegate?.podcastAutodownloadChanged(feedUrl: podcast.feedUrl)
         }
     }
     

--- a/Podverse/EpisodesTableViewController.swift
+++ b/Podverse/EpisodesTableViewController.swift
@@ -3,23 +3,29 @@ import CoreData
 
 class EpisodesTableViewController: PVViewController, UITableViewDataSource, UITableViewDelegate {
     
+    var episodesArray = [Episode]()
+    let moc = CoreDataHelper.createMOCForThread(threadType: .privateThread)
+    let reachability = PVReachability.shared
+    var selectedPodcastID: NSManagedObjectID!
     var showAllEpisodes = false
     
-    let moc = CoreDataHelper.createMOCForThread(threadType: .privateThread)
-    
-    var selectedPodcastID: NSManagedObjectID!
-    
-    var episodesArray = [Episode]()
-    
-    let reachability = PVReachability.shared
-    
+    @IBOutlet weak var autoDownloadButton: UIButton!
+    @IBOutlet weak var bottomButton: UITableView!
+    @IBOutlet weak var headerImageView: UIImageView!
+    @IBOutlet weak var headerPodcastTitle: UILabel!
     @IBOutlet weak var tableView: UITableView!
     
-    @IBOutlet weak var headerPodcastTitle: UILabel!
-    
-    @IBOutlet weak var headerImageView: UIImageView!
-    
-    @IBOutlet weak var bottomButton: UITableView!
+    @IBAction func autoDownloadButtonTouched(_ sender: Any) {
+        if let podcast = CoreDataHelper.fetchEntityWithID(objectId: self.selectedPodcastID, moc: moc) as? Podcast {
+            if podcast.shouldAutoDownload() {
+                podcast.removeFromAutoDownloadList()
+                self.autoDownloadButton.setTitle("Auto DL OFF", for: .normal)
+            } else {
+                podcast.addToAutoDownloadList()
+                self.autoDownloadButton.setTitle("Auto DL ON", for: .normal)
+            }
+        }
+    }
     
     @IBAction func bottomButtonTouched(_ sender: Any) {
         showAllEpisodes = !showAllEpisodes
@@ -46,6 +52,12 @@ class EpisodesTableViewController: PVViewController, UITableViewDataSource, UITa
                 DispatchQueue.main.async {
                     self.headerImageView.image = cellImage
                 }
+            }
+            
+            if podcast.shouldAutoDownload() {
+                self.autoDownloadButton.setTitle("Auto DL ON", for: .normal)
+            } else {
+                self.autoDownloadButton.setTitle("Auto DL OFF", for: .normal)
             }
             
             if (!showAllEpisodes) {

--- a/Podverse/EpisodesTableViewController.swift
+++ b/Podverse/EpisodesTableViewController.swift
@@ -9,20 +9,19 @@ class EpisodesTableViewController: PVViewController, UITableViewDataSource, UITa
     var selectedPodcastID: NSManagedObjectID!
     var showAllEpisodes = false
     
-    @IBOutlet weak var autoDownloadButton: UIButton!
+    @IBOutlet weak var autoDownloadLabel: UILabel!
+    @IBOutlet weak var autoDownloadSwitch: UISwitch!
     @IBOutlet weak var bottomButton: UITableView!
     @IBOutlet weak var headerImageView: UIImageView!
     @IBOutlet weak var headerPodcastTitle: UILabel!
     @IBOutlet weak var tableView: UITableView!
     
-    @IBAction func autoDownloadButtonTouched(_ sender: Any) {
+    @IBAction func autoDownloadSwitchTouched(_ sender: Any) {
         if let podcast = CoreDataHelper.fetchEntityWithID(objectId: self.selectedPodcastID, moc: moc) as? Podcast {
             if podcast.shouldAutoDownload() {
                 podcast.removeFromAutoDownloadList()
-                self.autoDownloadButton.setTitle("Auto DL OFF", for: .normal)
             } else {
                 podcast.addToAutoDownloadList()
-                self.autoDownloadButton.setTitle("Auto DL ON", for: .normal)
             }
         }
     }
@@ -55,9 +54,9 @@ class EpisodesTableViewController: PVViewController, UITableViewDataSource, UITa
             }
             
             if podcast.shouldAutoDownload() {
-                self.autoDownloadButton.setTitle("Auto DL ON", for: .normal)
+                self.autoDownloadSwitch.isOn = true
             } else {
-                self.autoDownloadButton.setTitle("Auto DL OFF", for: .normal)
+                self.autoDownloadSwitch.isOn = false
             }
             
             if (!showAllEpisodes) {

--- a/Podverse/MoreTableViewController.swift
+++ b/Podverse/MoreTableViewController.swift
@@ -16,6 +16,8 @@ class MoreTableViewController: PVViewController {
     
     override func viewDidLoad() {
         super.viewDidLoad()
+        
+        self.navigationItem.backBarButtonItem = UIBarButtonItem(title:"More", style:.plain, target:nil, action:nil)
     }
 
 }

--- a/Podverse/PVDeleter.swift
+++ b/Podverse/PVDeleter.swift
@@ -21,12 +21,14 @@ class PVDeleter: NSObject {
         let moc = CoreDataHelper.createMOCForThread(threadType: .privateThread)
         
         if let podcastId = podcastId, let podcast = CoreDataHelper.fetchEntityWithID(objectId: podcastId, moc: moc) as? Podcast {
+            podcast.removeFromAutoDownloadList()
             deleteAllEpisodesFromPodcast(podcast: podcast)
             moc.delete(podcast)
             DispatchQueue.main.async {
                 NotificationCenter.default.post(name: .podcastDeleted, object: nil, userInfo: ["feedUrl": podcast.feedUrl as? Any])
             }
         } else if let feedUrl = feedUrl, let podcast = Podcast.podcastForFeedUrl(feedUrlString: feedUrl, managedObjectContext: moc) {
+            podcast.removeFromAutoDownloadList()
             deleteAllEpisodesFromPodcast(podcast: podcast)
             moc.delete(podcast)
             DispatchQueue.main.async {

--- a/Podverse/PVFeedParser.swift
+++ b/Podverse/PVFeedParser.swift
@@ -204,7 +204,7 @@ extension PVFeedParser:FeedParserDelegate {
                     return
                 }
                 
-                if strongSelf.downloadMostRecentEpisode == true {
+                if strongSelf.downloadMostRecentEpisode == true && podcast.shouldAutoDownload() {
                     PVDownloader.shared.startDownloadingEpisode(episode: newEpisode)
                     strongSelf.downloadMostRecentEpisode = false
                 }
@@ -226,6 +226,7 @@ extension PVFeedParser:FeedParserDelegate {
                     PVDownloader.shared.startDownloadingEpisode(episode: latestEpisode)
                 }
             }
+            podcast.addToAutoDownloadList()
         }
         
         if let mostRecentEpisode = CoreDataHelper.fetchEntityWithMostRecentPubDate(className:"Episode", predicate: podcastPredicate, moc:moc) as? Episode {

--- a/Podverse/Podcast.swift
+++ b/Podverse/Podcast.swift
@@ -99,13 +99,10 @@ class Podcast: NSManagedObject {
     
     func shouldAutoDownload() -> Bool {
         if let autoDownloadingFeedUrls = UserDefaults.standard.array(forKey: kAutoDownloadingFeedUrls) as? [String] {
-            
-            let results = autoDownloadingFeedUrls.filter { $0 == self.feedUrl }
-            
-            if results.isEmpty {
-                return false
-            } else {
+            if autoDownloadingFeedUrls.contains(self.feedUrl) {
                 return true
+            } else {
+                return false
             }
         }
         
@@ -115,9 +112,7 @@ class Podcast: NSManagedObject {
     func addToAutoDownloadList() {
         
         if var autoDownloadingFeedUrls = UserDefaults.standard.array(forKey: kAutoDownloadingFeedUrls) as? [String] {
-            let results = autoDownloadingFeedUrls.filter { $0 == self.feedUrl }
-            
-            if results.isEmpty {
+            if !autoDownloadingFeedUrls.contains(self.feedUrl) {
                 autoDownloadingFeedUrls.append(self.feedUrl)
                 UserDefaults.standard.setValue(autoDownloadingFeedUrls, forKey: kAutoDownloadingFeedUrls)
             }

--- a/Podverse/Podcast.swift
+++ b/Podverse/Podcast.swift
@@ -96,4 +96,42 @@ class Podcast: NSManagedObject {
             return nil
         }
     }
+    
+    func shouldAutoDownload() -> Bool {
+        if let autoDownloadingFeedUrls = UserDefaults.standard.array(forKey: kAutoDownloadingFeedUrls) as? [String] {
+            
+            let results = autoDownloadingFeedUrls.filter { $0 == self.feedUrl }
+            
+            if results.isEmpty {
+                return false
+            } else {
+                return true
+            }
+        }
+        
+        return false
+    }
+    
+    func addToAutoDownloadList() {
+        
+        if var autoDownloadingFeedUrls = UserDefaults.standard.array(forKey: kAutoDownloadingFeedUrls) as? [String] {
+            let results = autoDownloadingFeedUrls.filter { $0 == self.feedUrl }
+            
+            if results.isEmpty {
+                autoDownloadingFeedUrls.append(self.feedUrl)
+                UserDefaults.standard.setValue(autoDownloadingFeedUrls, forKey: kAutoDownloadingFeedUrls)
+            }
+        } else {
+            UserDefaults.standard.setValue([self.feedUrl], forKey: kAutoDownloadingFeedUrls)
+        }
+        
+    }
+    
+    func removeFromAutoDownloadList() {
+        if let autoDownloadingFeedUrls = UserDefaults.standard.array(forKey: kAutoDownloadingFeedUrls) as? [String] {
+            let results = autoDownloadingFeedUrls.filter { $0 != self.feedUrl}
+            UserDefaults.standard.setValue(results, forKey: kAutoDownloadingFeedUrls)
+        }
+    }
+    
 }

--- a/Podverse/PodcastTableViewCell.swift
+++ b/Podverse/PodcastTableViewCell.swift
@@ -10,6 +10,7 @@ import UIKit
 
 class PodcastTableViewCell: UITableViewCell {
     
+    @IBOutlet weak var autoDownloadIndicator: UILabel!
     @IBOutlet weak var lastPublishedDate: UILabel!
     @IBOutlet weak var pvImage: UIImageView!
     @IBOutlet weak var title: UILabel!

--- a/Podverse/PodcastsTableViewController.swift
+++ b/Podverse/PodcastsTableViewController.swift
@@ -10,7 +10,7 @@ import UIKit
 import CoreData
 import Lock
 
-class PodcastsTableViewController: PVViewController {
+class PodcastsTableViewController: PVViewController, AutoDownloadProtocol {
 
     @IBOutlet weak var tableView: UITableView!
     
@@ -72,6 +72,13 @@ class PodcastsTableViewController: PVViewController {
         
         self.tableView.reloadData()
     }
+    
+    func podcastAutodownloadChanged(feedUrl: String) {
+        if let index = self.subscribedPodcastsArray.index(where: {$0.feedUrl == feedUrl}) {
+            self.tableView.reloadRows(at: [IndexPath(row: index, section: 0)], with: .none)
+        }
+    }
+    
 }
 
 extension PodcastsTableViewController:PVFeedParserDelegate {
@@ -175,6 +182,7 @@ extension PodcastsTableViewController:UITableViewDelegate, UITableViewDataSource
             if segue.identifier == "Show Episodes" {
                 let episodesTableViewController = segue.destination as! EpisodesTableViewController
                 episodesTableViewController.selectedPodcastID = subscribedPodcastsArray[index.row].objectID
+                episodesTableViewController.delegate = self
             }
         }
         

--- a/Podverse/PodcastsTableViewController.swift
+++ b/Podverse/PodcastsTableViewController.swift
@@ -125,13 +125,19 @@ extension PodcastsTableViewController:UITableViewDelegate, UITableViewDataSource
         
         cell.title?.text = podcast.title
         
+        if podcast.shouldAutoDownload() {
+            cell.autoDownloadIndicator?.text = "Auto DL ON"
+        } else {
+            cell.autoDownloadIndicator?.text = "Auto DL OFF"
+        }
+        
         let episodes = podcast.episodes
         let episodesDownloaded = episodes.filter{ $0.fileName != nil }
         cell.totalEpisodes?.text = "\(episodesDownloaded.count) downloaded"
                 
         cell.lastPublishedDate?.text = ""
         if let lastPubDate = podcast.lastPubDate {
-            //cell.lastPublishedDate?.text = PVUtility.formatDateToString(lastPubDate)
+            cell.lastPublishedDate?.text = lastPubDate.toShortFormatString()
         }
         
         cell.pvImage.image = Podcast.retrievePodcastImage(managedObjectID: podcast.objectID)


### PR DESCRIPTION
This seems to work, BUT there is a bug where if you toggle the Auto DL state on the EpisodeTVC, then navigate back to the PodcastTVC, the podcast's cell does not have the correct Auto DL cell.

Any ideas for a good way to handle that?

https://github.com/podverse/podverse-ios/issues/46 and https://github.com/podverse/podverse-ios/issues/50 can be closed after merge.