### PR TITLE
Sync subscribed podcasts list with server

### DIFF
--- a/Podverse/AudiosearchPodcast.swift
+++ b/Podverse/AudiosearchPodcast.swift
@@ -101,7 +101,7 @@ class AudiosearchPodcast {
             
             if isSubscribed == true {
                 podcastActions.addAction(UIAlertAction(title: "Unsubscribe", style: .default, handler: { action in
-                    PVDeleter.deletePodcast(feedUrl: feedUrl)
+                    PVSubscriber.unsubscribeFromPodcast(feedUrlString: feedUrl)
                 }))
             } else {
                 podcastActions.addAction(UIAlertAction(title: "Subscribe", style: .default, handler: { action in

--- a/Podverse/AudiosearchPodcastViewController.swift
+++ b/Podverse/AudiosearchPodcastViewController.swift
@@ -100,7 +100,7 @@ class AudiosearchPodcastViewController: PVViewController {
         let isSubscribed = PVSubscriber.checkIfSubscribed(feedUrlString: self.feedUrl)
         
         if isSubscribed {
-            PVDeleter.deletePodcast(feedUrl: self.feedUrl)
+            PVSubscriber.unsubscribeFromPodcast(feedUrlString: self.feedUrl)
         } else {
             DispatchQueue.global().async {
                 PVSubscriber.subscribeToPodcast(feedUrlString: self.feedUrl)

--- a/Podverse/PVSubscriber.swift
+++ b/Podverse/PVSubscriber.swift
@@ -14,6 +14,12 @@ class PVSubscriber {
     static func subscribeToPodcast(feedUrlString: String?) {
         
         if let feedUrlString = feedUrlString {
+            
+            // TODO: add error handling / connectivity error
+            updatePodcastOnServer(feedUrl: feedUrlString, shouldSubscribe: true) { wasSuccessful in
+                //
+            }
+            
             let feedParser = PVFeedParser(shouldOnlyGetMostRecentEpisode: false, shouldSubscribe: true)
             feedParser.parsePodcastFeed(feedUrlString: feedUrlString)
             
@@ -25,12 +31,65 @@ class PVSubscriber {
         
     }
     
+    static func unsubscribeFromPodcast(feedUrlString: String?) {
+        
+        if let feedUrlString = feedUrlString {
+            
+            // TODO: add error handling / connectivity error
+            updatePodcastOnServer(feedUrl: feedUrlString, shouldSubscribe: false) { wasSuccessful in
+                //
+            }
+            
+            PVDeleter.deletePodcast(feedUrl: feedUrlString)
+            
+        }
+        
+    }
+    
     static func checkIfSubscribed(feedUrlString: String?) -> Bool {
         if let feedUrlString = feedUrlString, let _ = Podcast.podcastForFeedUrl(feedUrlString: feedUrlString) {
             return true
         } else {
             return false
         }
+    }
+    
+    static func updatePodcastOnServer(feedUrl:String, shouldSubscribe:Bool, completion: @escaping (_ wasSuccessful:Bool?) -> Void) {
+        
+        let urlEnding = shouldSubscribe == true ? "subscribe" : "unsubscribe"
+        
+        if let url = URL(string: BASE_URL + "podcasts/" + urlEnding) {
+            var request = URLRequest(url: url, cachePolicy: NSURLRequest.CachePolicy.reloadIgnoringLocalAndRemoteCacheData, timeoutInterval: 60)
+            request.httpMethod = "POST"
+            
+            guard let idToken = UserDefaults.standard.string(forKey: "idToken") else {
+                return
+            }
+            
+            request.setValue(idToken, forHTTPHeaderField: "authorization")
+            
+            let postString = "podcastFeedURL=" + feedUrl
+            request.httpBody = postString.data(using: .utf8)
+            
+            let task = URLSession.shared.dataTask(with: request) { data, response, error in
+                
+                guard error == nil else {
+                    DispatchQueue.main.async {
+                        completion(false)
+                    }
+                    return
+                }
+                
+                DispatchQueue.main.async {
+                    completion(true)
+                }
+                
+            }
+            
+            task.resume()
+            
+        }
+        
     }
     
 }

--- a/Podverse/PVSubscriber.swift
+++ b/Podverse/PVSubscriber.swift
@@ -63,6 +63,9 @@ class PVSubscriber {
             request.httpMethod = "POST"
             
             guard let idToken = UserDefaults.standard.string(forKey: "idToken") else {
+                DispatchQueue.main.async {
+                    completion(false)
+                }
                 return
             }
             

--- a/Podverse/Podcast.swift
+++ b/Podverse/Podcast.swift
@@ -163,7 +163,7 @@ class Podcast: NSManagedObject {
         }
         
     }
-    
+        
     // TODO: This end point should be optimized better.
     static func retrieveSubscribedPodcastFeedUrlsFromServer(completion: @escaping (_ podcasts: [String]?) -> Void) {
         

--- a/Podverse/Podcast.swift
+++ b/Podverse/Podcast.swift
@@ -172,6 +172,9 @@ class Podcast: NSManagedObject {
             request.httpMethod = "POST"
             
             guard let idToken = UserDefaults.standard.string(forKey: "idToken") else {
+                DispatchQueue.main.async {
+                    completion([])
+                }
                 return
             }
             
@@ -204,6 +207,9 @@ class Podcast: NSManagedObject {
                         
                     } catch {
                         print("Error: " + error.localizedDescription)
+                        DispatchQueue.main.async {
+                            completion([])
+                        }
                     }
                 }
                 

--- a/Podverse/Podcast.swift
+++ b/Podverse/Podcast.swift
@@ -146,4 +146,72 @@ class Podcast: NSManagedObject {
         }
     }
     
+    // TODO: Don't pass in a delegate (switch FeedParser delegate methods to notifications?)
+    // TODO: Add placeholder podcasts to PodcastsTableVC when a feedUrl is returned by the server but is not saved in Core Data.
+    static func syncSubscribedPodcastsWithServer(delegate: PVFeedParserDelegate) {
+        
+        retrieveSubscribedPodcastFeedUrlsFromServer() { feedUrls in
+            if let feedUrls = feedUrls {
+                for feedUrl in feedUrls {
+                    let pvFeedParser = PVFeedParser(shouldOnlyGetMostRecentEpisode: true, shouldSubscribe:false)
+                    pvFeedParser.delegate = delegate
+                    if !ParsingPodcasts.shared.hasMatchingUrl(feedUrl: feedUrl) {
+                        pvFeedParser.parsePodcastFeed(feedUrlString: feedUrl)
+                    }
+                }
+            }
+        }
+        
+    }
+    
+    // TODO: This end point should be optimized better.
+    static func retrieveSubscribedPodcastFeedUrlsFromServer(completion: @escaping (_ podcasts: [String]?) -> Void) {
+        
+        if let url = URL(string: BASE_URL + "api/user/podcasts") {
+            var request = URLRequest(url: url, cachePolicy: NSURLRequest.CachePolicy.reloadIgnoringLocalAndRemoteCacheData, timeoutInterval: 60)
+            request.httpMethod = "POST"
+            
+            guard let idToken = UserDefaults.standard.string(forKey: "idToken") else {
+                return
+            }
+            
+            request.setValue(idToken, forHTTPHeaderField: "authorization")
+            
+            let task = URLSession.shared.dataTask(with: request) { data, response, error in
+                
+                guard error == nil else {
+                    DispatchQueue.main.async {
+                        completion([])
+                    }
+                    return
+                }
+                
+                if let data = data {
+                    do {
+                        var feedUrls = [String]()
+                        
+                        if let feedUrlsJSON = try JSONSerialization.jsonObject(with: data, options: []) as? [[String:Any]] {
+                            for item in feedUrlsJSON {
+                                if let feedUrl = item["feedURL"] as? String {
+                                    feedUrls.append(feedUrl)
+                                }
+                            }
+                        }
+                        
+                        DispatchQueue.main.async {
+                            completion(feedUrls)
+                        }
+                        
+                    } catch {
+                        print("Error: " + error.localizedDescription)
+                    }
+                }
+                
+            }
+            
+            task.resume()
+            
+        }
+    }
+    
 }

--- a/Podverse/PodcastsTableViewController.swift
+++ b/Podverse/PodcastsTableViewController.swift
@@ -49,6 +49,8 @@ class PodcastsTableViewController: PVViewController, AutoDownloadProtocol {
         refreshPodcastFeeds()
         loadPodcastData()
         
+        Podcast.syncSubscribedPodcastsWithServer(delegate:self)
+        
         addObservers()
     }
     

--- a/Podverse/PodcastsTableViewController.swift
+++ b/Podverse/PodcastsTableViewController.swift
@@ -212,11 +212,11 @@ extension PodcastsTableViewController:UITableViewDelegate, UITableViewDataSource
         
         let podcastToEditFeedUrl = self.subscribedPodcastsArray[indexPath.row].feedUrl
         
-        let deleteAction = UITableViewRowAction(style: .default, title: "Delete", handler: {action, indexpath in
+        let deleteAction = UITableViewRowAction(style: .default, title: "Unsubscribe", handler: {action, indexpath in
             self.subscribedPodcastsArray.remove(at: indexPath.row)
             tableView.deleteRows(at: [indexPath], with: .fade)
             
-            PVDeleter.deletePodcast(feedUrl: podcastToEditFeedUrl)
+            PVSubscriber.unsubscribeFromPodcast(feedUrlString: podcastToEditFeedUrl)
             
             if !checkForResults(results: self.subscribedPodcastsArray) {
                 self.loadNoPodcastsSubscribedMessage()


### PR DESCRIPTION
@kreonjr there is a bug where the the podcasts do not sync when you first login to the mobile app, but it works when you login the next time. 

If that is fixed, then I suppose this can be merged to master...however the fix may require switching the PVFeedParser delegate methods to notification methods, and that'd be a pretty substantial switch, so I'd like to get your thoughts on it when you get a chance.