### PR TITLE
Login / FeedParser notifications; syncSubscribedPodcastsWithServer on login

### DIFF
--- a/Podverse/AppDelegate.swift
+++ b/Podverse/AppDelegate.swift
@@ -143,12 +143,12 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     }
     
     func playOrPauseEvent() { 
-//        self.pvMediaPlayer.playOrPause()
-//        self.pvMediaPlayer.updateMPNowPlayingInfoCenter()
+        self.pvMediaPlayer.playOrPause()
+        self.pvMediaPlayer.updateMPNowPlayingInfoCenter()
     }
     
     func updatePlaybackPosition(event:MPChangePlaybackPositionCommandEvent) {
-//        self.pvMediaPlayer.seek(toTime: event.positionTime)
+        self.pvMediaPlayer.seek(toTime: event.positionTime)
     }
     
 }

--- a/Podverse/EpisodeTableViewController.swift
+++ b/Podverse/EpisodeTableViewController.swift
@@ -104,7 +104,6 @@ class EpisodeTableViewController: PVViewController {
     }
     
     fileprivate func setupNotificationListeners() {
-        NotificationCenter.default.addObserver(self, selector: #selector(self.feedParsingComplete(_:)), name: .feedParsingComplete, object: nil)
         NotificationCenter.default.addObserver(self, selector: #selector(self.downloadStarted(_:)), name: .downloadStarted, object: nil)
         NotificationCenter.default.addObserver(self, selector: #selector(self.downloadResumed(_:)), name: .downloadResumed, object: nil)
         NotificationCenter.default.addObserver(self, selector: #selector(self.downloadPaused(_:)), name: .downloadPaused, object: nil)
@@ -112,7 +111,6 @@ class EpisodeTableViewController: PVViewController {
     }
     
     fileprivate func removeObservers() {
-        NotificationCenter.default.removeObserver(self, name: .feedParsingComplete, object: nil)
         NotificationCenter.default.removeObserver(self, name: .downloadStarted, object: nil)
         NotificationCenter.default.removeObserver(self, name: .downloadResumed, object: nil)
         NotificationCenter.default.removeObserver(self, name: .downloadPaused, object: nil)
@@ -432,14 +430,6 @@ extension EpisodeTableViewController: UITableViewDataSource, UITableViewDelegate
 }
 
 extension EpisodeTableViewController {
-    
-    func feedParsingComplete(_ notification:Notification) {
-        if let url = notification.userInfo?["feedUrl"] as? String, url == self.feedUrl, self.filterTypeSelected != .clips {
-            DispatchQueue.main.async {
-                self.reloadEpisodeData()
-            }
-        }
-    }
     
     func updateButtonsByNotification(_ notification:Notification) {
         if let downloadingEpisode = notification.userInfo?[Episode.episodeKey] as? DownloadingEpisode, let dlMediaUrl = downloadingEpisode.mediaUrl, let mediaUrl = self.mediaUrl, dlMediaUrl == mediaUrl {

--- a/Podverse/EpisodeTableViewController.swift
+++ b/Podverse/EpisodeTableViewController.swift
@@ -104,6 +104,7 @@ class EpisodeTableViewController: PVViewController {
     }
     
     fileprivate func setupNotificationListeners() {
+        NotificationCenter.default.addObserver(self, selector: #selector(self.feedParsingComplete(_:)), name: .feedParsingComplete, object: nil)
         NotificationCenter.default.addObserver(self, selector: #selector(self.downloadStarted(_:)), name: .downloadStarted, object: nil)
         NotificationCenter.default.addObserver(self, selector: #selector(self.downloadResumed(_:)), name: .downloadResumed, object: nil)
         NotificationCenter.default.addObserver(self, selector: #selector(self.downloadPaused(_:)), name: .downloadPaused, object: nil)
@@ -111,6 +112,7 @@ class EpisodeTableViewController: PVViewController {
     }
     
     fileprivate func removeObservers() {
+        NotificationCenter.default.removeObserver(self, name: .feedParsingComplete, object: nil)
         NotificationCenter.default.removeObserver(self, name: .downloadStarted, object: nil)
         NotificationCenter.default.removeObserver(self, name: .downloadResumed, object: nil)
         NotificationCenter.default.removeObserver(self, name: .downloadPaused, object: nil)
@@ -430,6 +432,14 @@ extension EpisodeTableViewController: UITableViewDataSource, UITableViewDelegate
 }
 
 extension EpisodeTableViewController {
+    
+    func feedParsingComplete(_ notification:Notification) {
+        if let url = notification.userInfo?["feedUrl"] as? String, url == self.feedUrl, self.filterTypeSelected != .clips {
+            DispatchQueue.main.async {
+                self.reloadEpisodeData()
+            }
+        }
+    }
     
     func updateButtonsByNotification(_ notification:Notification) {
         if let downloadingEpisode = notification.userInfo?[Episode.episodeKey] as? DownloadingEpisode, let dlMediaUrl = downloadingEpisode.mediaUrl, let mediaUrl = self.mediaUrl, dlMediaUrl == mediaUrl {

--- a/Podverse/PVAuth.swift
+++ b/Podverse/PVAuth.swift
@@ -10,10 +10,6 @@ import Lock
 import Auth0
 import CoreData
 
-protocol PVAuthDelegate {
-    func loggedInSuccessfully()
-}
-
 extension Notification.Name {
     static let loggedInSuccessfully = Notification.Name(kLoggedInSuccessfully)
 }
@@ -21,8 +17,6 @@ extension Notification.Name {
 class PVAuth: NSObject {
     
     static let shared = PVAuth()
-    
-    var delegate:PVAuthDelegate?
     
     static var userIsLoggedIn:Bool {
         return UserDefaults.standard.value(forKey: "idToken") != nil
@@ -160,8 +154,6 @@ class PVAuth: NSObject {
         if let userName = userName {
             UserDefaults.standard.set(userName, forKey: "userName")
         }
-        
-        self.delegate?.loggedInSuccessfully()
     }
     
     func removeUserInfo() {

--- a/Podverse/PVDeleter.swift
+++ b/Podverse/PVDeleter.swift
@@ -29,6 +29,8 @@ class PVDeleter: NSObject {
                     return
                 }
                 
+                ParsingPodcasts.shared.removePodcast(podcastId: podcastId, feedUrl: nil)
+                
                 podcast = Podcast.podcastForId(id: podcastId, managedObjectContext: privateMoc)
             } else if let feedUrl = feedUrl {
                 
@@ -40,10 +42,9 @@ class PVDeleter: NSObject {
             } else {
                 return
             }
-
+            
             if let podcast = podcast {
                 DeletingPodcasts.shared.addPodcast(podcastId: podcast.id, feedUrl: podcast.feedUrl)
-                ParsingPodcasts.shared.removePodcast(podcastId: podcast.id, feedUrl: podcast.feedUrl)
                 podcast.removeFromAutoDownloadList()
                 deleteAllEpisodesFromPodcast(podcastId: podcast.id, feedUrl: podcast.feedUrl)
                 privateMoc.delete(podcast)

--- a/Podverse/PVSubscriber.swift
+++ b/Podverse/PVSubscriber.swift
@@ -23,10 +23,6 @@ class PVSubscriber {
             let feedParser = PVFeedParser(shouldOnlyGetMostRecentEpisode: false, shouldSubscribe: true, podcastId: podcastId)
             feedParser.parsePodcastFeed(feedUrlString: feedUrl)
             
-            DispatchQueue.main.async {
-                feedParser.delegate = ((UIApplication.shared.keyWindow?.rootViewController as? UITabBarController)?.viewControllers?.first as? UINavigationController)?.topViewController as? PodcastsTableViewController
-            }
-
         }
         
     }

--- a/Podverse/PlaylistsTableViewController.swift
+++ b/Podverse/PlaylistsTableViewController.swift
@@ -24,8 +24,6 @@ class PlaylistsTableViewController: PVViewController {
         
         self.activityIndicator.hidesWhenStopped = true
         
-        PVAuth.shared.delegate = self
-        
         retrievePlaylists()
         
     }
@@ -184,8 +182,10 @@ extension PlaylistsTableViewController:UITableViewDelegate, UITableViewDataSourc
     
 }
 
-extension PlaylistsTableViewController:PVAuthDelegate {
-    func loggedInSuccessfully() {
-        self.retrievePlaylists()
+extension PlaylistsTableViewController {
+    
+    func loggedInSuccessfully(_ notification:Notification) {
+        retrievePlaylists()
     }
+    
 }

--- a/Podverse/Podcast.swift
+++ b/Podverse/Podcast.swift
@@ -155,7 +155,7 @@ class Podcast: NSManagedObject {
         }
     }
     
-    static func syncSubscribedPodcastsWithServer(delegate: PVFeedParserDelegate) {
+    static func syncSubscribedPodcastsWithServer() {
         
         // Only podcasts that have an id will sync with the server. If a user manually adds a podcast by RSS feed locally to the app, it will not be saved to the server.
         retrieveSubscribedPodcastsFromServer() { syncPodcasts in
@@ -164,7 +164,6 @@ class Podcast: NSManagedObject {
                 for syncPodcast in syncPodcasts {
                     if let feedUrl = syncPodcast.feedUrl, let podcastId = syncPodcast.id {
                         let pvFeedParser = PVFeedParser(shouldOnlyGetMostRecentEpisode: true, shouldSubscribe: false, podcastId: syncPodcast.id)
-                        pvFeedParser.delegate = delegate
                         pvFeedParser.parsePodcastFeed(feedUrlString: feedUrl)
                     }
                 }

--- a/Podverse/SearchPodcast.swift
+++ b/Podverse/SearchPodcast.swift
@@ -205,6 +205,10 @@ class SearchPodcast {
                 podcastActions.addAction(UIAlertAction(title: "Unsubscribe", style: .default, handler: { action in
                     PVSubscriber.unsubscribeFromPodcast(podcastId: id, feedUrl: nil)
                 }))
+            } else if ParsingPodcasts.shared.hasMatchingId(podcastId: id) {
+                podcastActions.addAction(UIAlertAction(title: "Unsubscribe", style: .default, handler: { action in
+                    PVSubscriber.unsubscribeFromPodcast(podcastId: id, feedUrl: nil)
+                }))
             } else {
                 podcastActions.addAction(UIAlertAction(title: "Subscribe", style: .default, handler: { action in
                     self.authorityFeedUrlForPodcast(id: id) { feedUrl in


### PR DESCRIPTION
This PR fixes an issue with the PVAuth failing to call Podcast.syncSubscribedPodcastsWithServer after a user logs in.

I went ahead and switched PVFeedParser from a delegate to a notification along with it...and I'm starting to think that was unnecessary 😬 yeah, I can't think of a good reason for doing that. Let me know if this is an issue.

Also, I accidentally included the other PR branch with this one 🤦‍♂️