### PR TITLE
Fix first time parse after sync bug

### DIFF
--- a/Podverse/PVFeedParser.swift
+++ b/Podverse/PVFeedParser.swift
@@ -51,9 +51,7 @@ class PVFeedParser {
             return
         }
 
-        if !self.downloadMostRecentEpisode {
-            self.parsingPodcasts.addPodcast(podcastId: self.podcastId, feedUrl: feedUrlString)
-        }
+        self.parsingPodcasts.addPodcast(podcastId: self.podcastId, feedUrl: feedUrlString)
         
         self.feedUrl = feedUrlString
         
@@ -229,7 +227,7 @@ class PVFeedParser {
                     self.downloadMostRecentEpisode = false
                 }
                 
-                if self.onlyGetMostRecentEpisode {
+                if self.onlyGetMostRecentEpisode && !self.subscribeToPodcast {
                     break
                 }
             }
@@ -359,7 +357,7 @@ class PVFeedParser {
                     self.downloadMostRecentEpisode = false
                 }
                 
-                if self.onlyGetMostRecentEpisode {
+                if self.onlyGetMostRecentEpisode && !self.subscribeToPodcast {
                     break
                 }
             }
@@ -470,7 +468,7 @@ class PVFeedParser {
                     self.downloadMostRecentEpisode = false
                 }
                 
-                if self.onlyGetMostRecentEpisode {
+                if self.onlyGetMostRecentEpisode && !self.subscribeToPodcast {
                     break
                 }
             }

--- a/Podverse/Podcast.swift
+++ b/Podverse/Podcast.swift
@@ -88,6 +88,20 @@ class Podcast: NSManagedObject {
         }
     }
     
+    static func retrieveSubscribedIds() -> [String] {
+        let moc = CoreDataHelper.createMOCForThread(threadType: .privateThread)
+        var subscribedPodcastIds = [String]()
+        let subscribedPodcastsArray = CoreDataHelper.fetchEntities(className:"Podcast", predicate: nil, moc:moc) as! [Podcast]
+        
+        for podcast in subscribedPodcastsArray {
+            if let id = podcast.id {
+                subscribedPodcastIds.append(id)
+            }
+        }
+        
+        return subscribedPodcastIds
+    }
+
     static func retrieveSubscribedUrls() -> [String] {
         let moc = CoreDataHelper.createMOCForThread(threadType: .privateThread)
         var subscribedPodcastFeedUrls = [String]()
@@ -166,9 +180,16 @@ class Podcast: NSManagedObject {
                 return
             }
             
+            let subscribedIds = self.retrieveSubscribedIds()
+            
             for syncPodcast in syncPodcasts {
                 if let feedUrl = syncPodcast.feedUrl {
-                    let pvFeedParser = PVFeedParser(shouldOnlyGetMostRecentEpisode: true, shouldSubscribe: false, podcastId: syncPodcast.id)
+                    var shouldSubscribe = false
+                    if let id = syncPodcast.id, !subscribedIds.contains(id) {
+                        shouldSubscribe = true
+                    }
+                    
+                    let pvFeedParser = PVFeedParser(shouldOnlyGetMostRecentEpisode: true, shouldSubscribe: shouldSubscribe, podcastId: syncPodcast.id)
                     pvFeedParser.parsePodcastFeed(feedUrlString: feedUrl)
                 }
             }


### PR DESCRIPTION
There was a flaw in the logic that resulted in only the first episode being parsed when syncing a user’s subscribed podcasts with the server then parsing a podcast for the first time.