### PR TITLE
Add crashlytics

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -15,6 +15,8 @@ target 'Podverse' do
   pod 'StreamingKit', :git => 'https://github.com/podverse/StreamingKit.git', :branch => 'master'
   pod 'SDWebImage', '~> 4.0'
   pod 'FeedKit', '~> 6.0'
+  pod 'Fabric'
+  pod 'Crashlytics'
 
   target 'PodverseTests' do
     inherit! :search_paths

--- a/Podverse.xcodeproj/project.pbxproj
+++ b/Podverse.xcodeproj/project.pbxproj
@@ -516,6 +516,7 @@
 				E79515D71E03853400382BF8 /* Resources */,
 				EC2BE28CAC6A390DE7FB9C13 /* [CP] Embed Pods Frameworks */,
 				E737A0CE20CF78C900FAAF3D /* Increment Build */,
+				30990D8C2117DEB10035EBC1 /* ShellScript */,
 			);
 			buildRules = (
 			);
@@ -652,6 +653,21 @@
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXShellScriptBuildPhase section */
+		30990D8C2117DEB10035EBC1 /* ShellScript */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+				"",
+				"$(BUILT_PRODUCTS_DIR)/$(INFOPLIST_PATH)",
+			);
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${PODS_ROOT}/Fabric/run\" 4de8d263bbd958f598aae11ba2d716f6c29190e9 85449ae06a7d8cfa11358811783a829eff1cbea8b81283e038932322c9555beb";
+		};
 		67AC66BCB6B3CCEE974AE601 /* [CP] Check Pods Manifest.lock */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;

--- a/Podverse/AppDelegate.swift
+++ b/Podverse/AppDelegate.swift
@@ -11,6 +11,8 @@ import AVFoundation
 import MediaPlayer
 import Lock
 import UserNotifications
+import Fabric
+import Crashlytics
 
 @UIApplicationMain
 class AppDelegate: UIResponder, UIApplicationDelegate, UNUserNotificationCenterDelegate {
@@ -36,6 +38,8 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UNUserNotificationCenterD
     }
     
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplicationLaunchOptionsKey: Any]?) -> Bool {
+        
+        Fabric.with([Crashlytics.self])
         
         // Enable the media player to continue playing in the background and on the lock screen
         // Enable the media player to use remote control events

--- a/Podverse/Info.plist
+++ b/Podverse/Info.plist
@@ -30,7 +30,21 @@
 		</dict>
 	</array>
 	<key>CFBundleVersion</key>
-	<string>7</string>
+	<string>8</string>
+	<key>Fabric</key>
+	<dict>
+		<key>APIKey</key>
+		<string>4de8d263bbd958f598aae11ba2d716f6c29190e9</string>
+		<key>Kits</key>
+		<array>
+			<dict>
+				<key>KitInfo</key>
+				<dict/>
+				<key>KitName</key>
+				<string>Crashlytics</string>
+			</dict>
+		</array>
+	</dict>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
 	<key>NSAppTransportSecurity</key>


### PR DESCRIPTION
As far as I can tell, this _seems_ to be setup properly, but Crashlytics is still failing because of a "dSym not found" issue.

Is this something we can only make work with a release build? [related](https://stackoverflow.com/questions/35159244/xcode-there-are-no-dsyms-available-for-download)