### PR TITLE
Request task queue

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -15,6 +15,7 @@ target 'Podverse' do
   pod 'StreamingKit', :git => 'https://github.com/podverse/StreamingKit.git', :branch => 'master'
   pod 'SDWebImage', '~> 4.0'
   pod 'FeedKit', '~> 6.0'
+  pod 'TaskQueue'
 
   target 'PodverseTests' do
     inherit! :search_paths

--- a/Podverse.xcodeproj/project.pbxproj
+++ b/Podverse.xcodeproj/project.pbxproj
@@ -735,6 +735,7 @@
 				"${BUILT_PRODUCTS_DIR}/SDWebImage/SDWebImage.framework",
 				"${BUILT_PRODUCTS_DIR}/SimpleKeychain/SimpleKeychain.framework",
 				"${BUILT_PRODUCTS_DIR}/StreamingKit/StreamingKit.framework",
+				"${BUILT_PRODUCTS_DIR}/TaskQueue/TaskQueue.framework",
 				"${BUILT_PRODUCTS_DIR}/p2.OAuth2/p2_OAuth2.framework",
 			);
 			name = "[CP] Embed Pods Frameworks";
@@ -747,6 +748,7 @@
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/SDWebImage.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/SimpleKeychain.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/StreamingKit.framework",
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/TaskQueue.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/p2_OAuth2.framework",
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/Podverse/PVSubscriber.swift
+++ b/Podverse/PVSubscriber.swift
@@ -22,7 +22,6 @@ class PVSubscriber {
             
             let feedParser = PVFeedParser(shouldOnlyGetMostRecentEpisode: false, shouldSubscribe: true, podcastId: podcastId)
             feedParser.addToParsingQueue(feedUrlString: feedUrl)
-            
         }
         
     }

--- a/Podverse/PVSubscriber.swift
+++ b/Podverse/PVSubscriber.swift
@@ -21,7 +21,7 @@ class PVSubscriber {
             }
             
             let feedParser = PVFeedParser(shouldOnlyGetMostRecentEpisode: false, shouldSubscribe: true, podcastId: podcastId)
-            feedParser.parsePodcastFeed(feedUrlString: feedUrl)
+            feedParser.addToParsingQueue(feedUrlString: feedUrl)
             
         }
         

--- a/Podverse/ParsingPodcasts.swift
+++ b/Podverse/ParsingPodcasts.swift
@@ -8,6 +8,7 @@
 
 import Foundation
 import UIKit
+import TaskQueue
 
 final class ParsingPodcasts {
     static let shared = ParsingPodcasts()
@@ -19,6 +20,8 @@ final class ParsingPodcasts {
         }
     }
     var currentlyParsingItem = 0
+    
+    let queue = TaskQueue()
     
     func clearParsingPodcastsIfFinished() {
         if currentlyParsingItem == podcastKeys.count {

--- a/Podverse/ParsingPodcasts.swift
+++ b/Podverse/ParsingPodcasts.swift
@@ -23,6 +23,10 @@ final class ParsingPodcasts {
     
     let queue = TaskQueue()
     
+    init() {
+        self.queue.maximumNumberOfActiveTasks = 4
+    }
+    
     func clearParsingPodcastsIfFinished() {
         if currentlyParsingItem == podcastKeys.count {
             currentlyParsingItem = 0

--- a/Podverse/Podcast.swift
+++ b/Podverse/Podcast.swift
@@ -223,6 +223,8 @@ class Podcast: NSManagedObject {
                     pvFeedParser.addToParsingQueue(feedUrlString: feedUrl)
                 }
             }
+                        
+            completionBlock?()
             
         }
         

--- a/Podverse/Podcast.swift
+++ b/Podverse/Podcast.swift
@@ -220,10 +220,10 @@ class Podcast: NSManagedObject {
                     }
                     
                     let pvFeedParser = PVFeedParser(shouldOnlyGetMostRecentEpisode: true, shouldSubscribe: shouldSubscribe, podcastId: syncPodcast.id)
-                    pvFeedParser.parsePodcastFeed(feedUrlString: feedUrl)
+                    pvFeedParser.addToParsingQueue(feedUrlString: feedUrl)
                 }
             }
-
+            
         }
         
     }

--- a/Podverse/PodcastsTableViewController.swift
+++ b/Podverse/PodcastsTableViewController.swift
@@ -129,7 +129,7 @@ class PodcastsTableViewController: PVViewController, AutoDownloadProtocol {
                 
                 let pvFeedParser = PVFeedParser(shouldOnlyGetMostRecentEpisode: true, shouldSubscribe:false, podcastId: podcastId)
                 if let feedUrlString = feedUrl?.absoluteString {
-                    pvFeedParser.parsePodcastFeed(feedUrlString: feedUrlString)
+                    pvFeedParser.addToParsingQueue(feedUrlString: feedUrlString)
                 }
             }
         }

--- a/Podverse/PodcastsTableViewController.swift
+++ b/Podverse/PodcastsTableViewController.swift
@@ -132,6 +132,7 @@ class PodcastsTableViewController: PVViewController, AutoDownloadProtocol {
                     pvFeedParser.addToParsingQueue(feedUrlString: feedUrlString)
                 }
             }
+            
         }
 
         self.refreshControl.endRefreshing()
@@ -322,11 +323,18 @@ extension PodcastsTableViewController {
     }
     
     @objc func loggedInSuccessfully() {
-        DispatchQueue.global().async {
-            Podcast.syncSubscribedPodcastsWithServer()
-        }
         self.parseStatus.text = "Syncing with server"
         self.parseActivityIndicator.startAnimating()
+        
+        DispatchQueue.global().async {
+            Podcast.syncSubscribedPodcastsWithServer() {
+                // In case 0 results are found, call refreshParsingStatus status in the completion block so "syncing with server" text is removed.
+                DispatchQueue.main.async {
+                    self.refreshParsingStatus()
+                }
+            }
+        }
+
     }
     
     @objc func loggedOutSuccessfully() {
@@ -353,7 +361,7 @@ extension PodcastsTableViewController {
         }
     }
     
-    @objc func refreshParsingStatus(_ notification:Notification) {
+    @objc func refreshParsingStatus(_ notification:Notification? = nil) {
         let total = self.parsingPodcasts.podcastKeys.count
         let currentItem = self.parsingPodcasts.currentlyParsingItem
         


### PR DESCRIPTION
@kreonjr this seems to work for the parsing podcasts queue. It limits the maximum active parsing tasks to 4, so the app can't get overloaded with like 20+ parsing jobs at once.

I was about to try to create a download episodes task queue with this...but we'll need to be able to manually grab and stop downloads on the queue, and this icanzilb/TaskQueue library does not seem to be able to support that :( at least with our current implementation.

We can talk over the download episodes task queue sometime, but for now, I'm thinking we could be fine without it. It's less of a problem than the ParsingPodcasts queue overloading the app with requests, because a user can go in and manually start/stop downloading an episode, but the parsing queue was automatically handled without user control.